### PR TITLE
Compile with closure compiler and gzip output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,14 @@ cabal.sandbox.config
 *.hp
 *.eventlog
 .DS_Store
+
+### Stack
 .stack-work/
+.stack-work-profile/
+.stack-work-production/
 cabal.project.local
+
+### Project Specific
 release/
 InnerEar.db
 

--- a/Makefile
+++ b/Makefile
@@ -52,12 +52,18 @@ ghciServer:
 # development builds
 
 PRODUCTION_WORK_DIR=.stack-work-production/
+PRODUCTION_INSTALL_DIR=$$(stack --work-dir $(PRODUCTION_WORK_DIR) path --local-install-root)/bin/InnerEarClient.jsexe
 
 prodBuildClient:
 	cd client && stack --work-dir $(PRODUCTION_WORK_DIR) build --ghc-options="-DGHCJS_BROWSER -O2"
+	cd client && google-closure-compiler "$(PRODUCTION_INSTALL_DIR)/all.js" --compilation_level=ADVANCED_OPTIMIZATIONS --jscomp_off=checkVars --js_output_file="$(PRODUCTION_INSTALL_DIR)/all.min.js"
+	cd client && gzip -fk $(PRODUCTION_WORK_DIR)/all.min.js
 
 releaseProdClient:
-	cd client && cp -Rf $$(stack --work-dir $(PRODUCTION_WORK_DIR) path --local-install-root)/bin/InnerEarClient.jsexe ../release/	
+	cd client && cp -Rf $(PRODUCTION_INSTALL_DIR) ../release/
+	cd client && cp -Rf ../static/* ../release/InnerEarClient.jsexe/
+	cd client && cp $(PRODUCTION_INSTALL_DIR)/all.min.js.gz ../release/InnerEarClient.jsexe/
+	cp client/index.html release/InnerEarClient.jsexe/index.html
 
 # profile builds
 

--- a/Makefile
+++ b/Makefile
@@ -47,3 +47,19 @@ buildReleaseTest: buildClient buildServer release bootServer
 
 ghciServer:
 	cd server && stack ghci
+
+
+# development builds
+
+PRODUCTION_WORK_DIR=.stack-work-production/
+
+prodBuildClient:
+	cd client && stack --work-dir $(PRODUCTION_WORK_DIR) build --ghc-options="-DGHCJS_BROWSER -O2"
+
+releaseProdClient:
+	cd client && cp -Rf $$(stack --work-dir $(PRODUCTION_WORK_DIR) path --local-install-root)/bin/InnerEarClient.jsexe ../release/	
+
+# profile builds
+
+profBuildClient:
+	cd client && stack build --profile

--- a/client/InnerEarClient.cabal
+++ b/client/InnerEarClient.cabal
@@ -15,6 +15,7 @@ extra-source-files:
 
 executable InnerEarClient
   hs-source-dirs:    src
+  js-sources:        ../static/InnerEarWebSocket.js ../static/reflex-synth.js
   main-is:           InnerEarClient.hs
   build-depends:     base, reflex, reflex-dom,reflex-dom-contrib, containers, safe, ghcjs-base, ghcjs-dom,
                      text, array, ghcjs-prim, data-default, transformers, file-embed, time, tuple,

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link href="style.css" rel="stylesheet" type="text/css"/>
+    <script language="javascript" src="all.min.js"></script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/client/stack.yaml
+++ b/client/stack.yaml
@@ -11,6 +11,18 @@ setup-info:
 build:
   haddock-hyperlink-source: false
 
+ghc-options:
+  # possibly th times/memory too high but the simplifier runs out of ticks or runs too long to wait for the end
+  json: -funfolding-use-threshold=16
+  # reference errors when using the complicated, optimized interfaces and TH. Omiting them and falling back to the simple
+  # ones seems to work great! This is the default for -O0 anyways so adding it only affects the profile builds
+  # which don't work without it.
+  th-reify-many: -fomit-interface-pragmas
+  safe: -fomit-interface-pragmas
+  lens: -fomit-interface-pragmas
+  profunctors: -fomit-interface-pragmas
+  contravariant: -fomit-interface-pragmas
+
 allow-newer: true
 
 packages:

--- a/client/stack.yaml
+++ b/client/stack.yaml
@@ -1,6 +1,18 @@
+#resolver: lts-8.11
+#compiler: ghcjs-0.2.1.9008011_ghc-8.0.2i
+#compiler-check: match-exact
+#
+#setup-info:
+#  ghcjs:
+#    source:
+#      ghcjs-0.2.1.9008011_ghc-8.0.2:
+#        url: https://github.com/matchwood/ghcjs-stack-dist/raw/master/ghcjs-0.2.1.9008011.tar.gz
+#        sha1: a72a5181124baf64bcd0e68a8726e65914473b3b
+
 resolver: lts-6.30
 compiler: ghcjs-0.2.0.9006030_ghc-7.10.3
 compiler-check: match-exact
+
 setup-info:
   ghcjs:
     source:
@@ -22,6 +34,7 @@ ghc-options:
   lens: -fomit-interface-pragmas
   profunctors: -fomit-interface-pragmas
   contravariant: -fomit-interface-pragmas
+ # reflex-dom-contrib: -fexternal-interpreter
 
 allow-newer: true
 

--- a/server/InnerEarServer.cabal
+++ b/server/InnerEarServer.cabal
@@ -17,5 +17,6 @@ executable InnerEarServer
   hs-source-dirs:    src
   main-is:           InnerEarServer.hs
   build-depends:     base, containers, text, json, websockets, time, tuple, transformers,
-                     wai, warp, wai-websockets, wai-app-static, sqlite-simple, either, mtl, errors
+                     wai, warp, wai-websockets, wai-app-static, wai-extra,
+                     sqlite-simple, either, mtl, errors
   default-language:  Haskell2010

--- a/src/InnerEar/Exercises/MultipleChoice.hs
+++ b/src/InnerEar/Exercises/MultipleChoice.hs
@@ -4,7 +4,6 @@ module InnerEar.Exercises.MultipleChoice where
 
 import Reflex
 import Reflex.Dom
-import Reflex.Dom.Contrib.Widgets.ButtonGroup (radioGroup)
 import Reflex.Dom.Contrib.Widgets.Common
 import Data.Map
 import Control.Monad (zipWithM)
@@ -193,20 +192,6 @@ randomMultipleChoiceQuestion possibilities = do
   let n = length possibilities
   x <- getStdRandom ((randomR (0,n-1))::StdGen -> (Int,StdGen))
   return (possibilities,possibilities!!x)
-
-radioConfigWidget :: (MonadWidget t m, Eq a, Show a) => String -> String -> [a] -> a -> m (Event t a)
-radioConfigWidget explanation msg possibilities i = do
-  let radioButtonMap =  zip [0::Int,1..] possibilities
-  let iVal = maybe 0 id $ elemIndex i possibilities
-  elClass "div" "explanation" $ text explanation
-  elClass "div" "configText" $ text msg
-  radioWidget <- radioGroup (constDyn "radioWidget") (constDyn $ fmap (\(x,y)->(x,show y)) radioButtonMap)
-           (WidgetConfig {_widgetConfig_initialValue= Just iVal
-                         ,_widgetConfig_setValue = never
-                         ,_widgetConfig_attributes = constDyn empty})
-  dynConfig <- holdDyn i $ fmap (\x-> maybe i id $ Data.Map.lookup (maybe 0 id x) (fromList radioButtonMap)) (_hwidget_change radioWidget)
-  b <- button "Begin Exercise"
-  return $ tagDyn dynConfig b
 
 trivialBWidget :: MonadWidget t m => m (Dynamic t ())
 trivialBWidget = holdDyn () $ never

--- a/src/InnerEar/Widgets/Utility.hs
+++ b/src/InnerEar/Widgets/Utility.hs
@@ -10,7 +10,6 @@ import Data.List (elemIndex)
 import Data.Map
 import Reflex
 import Reflex.Dom
-import Reflex.Dom.Contrib.Widgets.ButtonGroup (radioGroup)
 import Reflex.Dom.Contrib.Widgets.Common
 import Control.Monad ((>=>))
 import Control.Monad.IO.Class (liftIO)


### PR DESCRIPTION
Add the Makefile targets for building a production release of the project. This includes using the [google-closure-compiler](https://www.npmjs.com/package/google-closure-compiler) to minify and `gzip` to compress.